### PR TITLE
Add powerline plugin for vim

### DIFF
--- a/vimrc/powerline.vim
+++ b/vimrc/powerline.vim
@@ -1,0 +1,8 @@
+python3 from powerline.vim import setup as powerline_setup
+python3 powerline_setup()
+python3 del powerline_setup
+
+set laststatus=2 " Always display the statusline in all windows
+set showtabline=2 " Always display the tabline, even if there is only one tab
+set noshowmode " Hide the default mode text (e.g. -- INSERT -- below the statusline)
+set t_Co=256


### PR DESCRIPTION
Powerline is a statusline plugin for vim and provides statuslines and prompts.

### Installation

```bash
pip install powerline
pip install --user powerline-status
wget https://github.com/powerline/powerline/raw/develop/font/PowerlineSymbols.otf
wget https://github.com/powerline/powerline/raw/develop/font/10-powerline-symbols.conf
mkdir ~/.fonts
mv PowerlineSymbols.otf ~/.fonts/
fc-cache -vf ~/.fonts/
mv 10-powerline-symbols.conf ~/.config/fontconfig/conf.d/
```

### Examples

![image](https://user-images.githubusercontent.com/6709378/170490026-94cbdfaa-7a3a-4dd5-8731-2ba9cbeec602.png)

![image](https://user-images.githubusercontent.com/6709378/170490081-687c4e89-5d9b-4a07-91b7-f5a22ac06a4f.png)

![image](https://user-images.githubusercontent.com/6709378/170490139-aa2cab95-ef36-4dc6-a859-6cbcfc2733bb.png)

### More info
- GitHub repo - https://github.com/powerline/powerline
- Instllation on Linux - https://powerline.readthedocs.io/en/master/installation/linux.html
- Add Powerline configurations - https://fedoramagazine.org/add-power-terminal-powerline/