### PR TITLE
Add markdown-preview plugin

### DIFF
--- a/vimrc/.vimrc
+++ b/vimrc/.vimrc
@@ -37,6 +37,9 @@ Plug 'editorconfig/editorconfig-vim'
 " Intelligently reopen files at the last edit position
 Plug 'farmergreg/vim-lastplace'
 
+" Markdown preview
+Plug 'iamcco/markdown-preview.nvim', { 'do': 'cd app && yarn install' }
+
 " Insert or delete brackets, parens and quotes in pair
 Plug 'jiangmiao/auto-pairs'
 

--- a/vimrc/plugins.vim
+++ b/vimrc/plugins.vim
@@ -83,7 +83,18 @@ let g:lastplace_ignore_buftype = "quickfix,nofile,help"
 let g:lastplace_open_folds = 0
 
 " .............................................................................
-" 'jremmen/vim-ripgrep'
+" iamcco/markdown-preview.nvim
+" .............................................................................
+
+" Open the preview window automatically after entering the markdown buffer
+let g:mkdp_auto_start = 1
+
+nmap <C-s> <Plug>MarkdownPreview
+nmap <M-s> <Plug>MarkdownPreviewStop
+nmap <C-m> <Plug>MarkdownPreviewToggle
+
+" .............................................................................
+" jremmen/vim-ripgrep
 " .............................................................................
 
 if executable('rg')


### PR DESCRIPTION
The plugin shows the markdown code in a web browser. An advantage of this plugin is that GitHub uses the same plugin which means that what I see locally will be exactly displayed in GitHub (Or to be accurate - almost the same).

For more info click [here](https://github.com/iamcco/markdown-preview.nvim).