### PR TITLE
Fix tmux font issues on Ubuntu

### DIFF
--- a/bashrc/.bash_aliases
+++ b/bashrc/.bash_aliases
@@ -166,6 +166,7 @@ alias reload='source ~/.bashrc'
 alias s2='saml2aws login'
 alias speedtest='curl -s https://raw.githubusercontent.com/sivel/speedtest-cli/master/speedtest.py | python -'
 alias tf='terraform fmt'
+alias tmux='tmux -u'
 alias tmuxr='tmux source-file ~/.tmux.conf'
 alias tree='tree --dirsfirst -F' # Display the directory structure better
 alias vai='vainfo'


### PR DESCRIPTION
For more info read this [StackOverFlow post](https://stackoverflow.com/questions/67929676/tmux-powerline-symbols-not-rendering-properly-despite-having-proper-fonts-instal#fromHistory#fromHistory).